### PR TITLE
Nom parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,12 +127,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "msb"
 version = "0.0.6"
 dependencies = [
  "clap",
  "error-stack",
+ "nom",
  "thiserror",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ repository = "https://github.com/prodbysky/msb"
 [dependencies]
 clap = { version = "4.5.28", features = ["derive"] }
 error-stack = "0.5.0"
+nom = "8.0.0"
 thiserror = "2.0.11"

--- a/examples/complex/complex_math.msb
+++ b/examples/complex/complex_math.msb
@@ -2,19 +2,19 @@ target main [files(main.c) targets(add, sub, mul, div)] {
     gcc main.c -o main add.o sub.o mul.o div.o
 }
 
-target add [files(add.c, add.h) targets()] {
+target add [files(add.c add.h) targets()] {
     gcc add.c -c -o add.o
 }
 
-target sub [files(sub.c, sub.h) targets()] {
+target sub [files(sub.c sub.h) targets()] {
     gcc sub.c -c -o sub.o
 }
 
 
-target mul [files(mul.c, mul.h) targets()] {
+target mul [files(mul.c mul.h) targets()] {
     gcc mul.c -c -o mul.o
 }
 
-target div [files(div.c, div.h) targets()] {
+target div [files(div.c div.h) targets()] {
     gcc div.c -c -o div.o
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 fn main() -> AppResult {
     let config = Config::parse();
     if let Err(e) = config.validate() {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {e}");
         eprintln!("Run with -h to print help");
         std::process::exit(1);
     }
@@ -16,27 +16,27 @@ fn main() -> AppResult {
     let input_content =
         std::fs::read_to_string(&config.input_name).change_context(AppError::FailedToReadInput)?;
 
-    let targets = target::Makefile::from_str(input_content.as_str())
-        .change_context(AppError::FailedToParseBuildFile)
+    let targets = target::parse_makefile(&input_content)
+        .ok_or(AppError::FailedToParseBuildFile)
         .attach_printable("failed to parse the .msb file")?;
 
     if config.print_targets {
         for (i, target) in targets.get_targets().iter().enumerate() {
             println!("{}: {}", i, target.name());
             if target.file_dependencies().is_empty() && target.target_dependencies().is_empty() {
-                println!("Does not depend on anything")
+                println!("Does not depend on anything");
             } else {
                 println!("Depends on:");
                 if !target.file_dependencies().is_empty() {
                     println!("  These files:");
                     for f in target.file_dependencies() {
-                        println!("    {}", f);
+                        println!("    {f}");
                     }
                 }
                 if !target.target_dependencies().is_empty() {
                     println!("  These targets:");
                     for t in target.target_dependencies() {
-                        println!("    {}", t);
+                        println!("    {t}");
                     }
                 }
             }


### PR DESCRIPTION
We are using nom for parsing
Now file and target dependency names are NOT separated by commas
And that's the only breaking change in this PR.