### PR TITLE
Command parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "msb"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "error-stack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msb"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["prodbysky"]
 license = "MIT"

--- a/examples/tsoding_ded.msb
+++ b/examples/tsoding_ded.msb
@@ -1,5 +1,5 @@
 target main [files() targets(source)] {
-    gcc -Wall -Wextra -std=c11 -pedantic -ggdb -I/usr/include/SDL2 -D_REENTRANT -I/usr/include/freetype2 -I/usr/include/libpng16 -DWITH_GZFILEOP -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-6 -pthread -o ded/ded ded/src/main.c ded/src/la.c ded/src/editor.c ded/src/file_browser.c ded/src/free_glyph.c ded/src/simple_renderer.c ded/src/common.c ded/src/lexer.c -lm -lSDL2 -lGLEW -lGL -lX11 -lGLU -lOpenGL -lfreetype
+    gcc -Wall -Wextra -std=c11 -pedantic -ggdb $(pkg-config --cflags sdl2 freetype2 glew) $(pkg-config --libs sdl2 freetype2 glew) -o ded/ded ded/src/main.c ded/src/la.c ded/src/editor.c ded/src/file_browser.c ded/src/free_glyph.c ded/src/simple_renderer.c ded/src/common.c ded/src/lexer.c -lm
 }
 
 target source [files() targets()] {

--- a/src/target.rs
+++ b/src/target.rs
@@ -128,17 +128,10 @@ impl Target {
             return Ok(());
         }
 
-        // TODO: Proper command line parsing
         let mut children = vec![];
         for cmd in &self.commands {
-            let parts: Vec<&str> = cmd.split_whitespace().collect();
-            if parts.is_empty() {
-                continue;
-            }
-            let exe = parts[0];
-            let args = &parts[1..];
-            let mut command = std::process::Command::new(exe);
-            command.args(args);
+            let mut command = std::process::Command::new("sh");
+            command.arg("-c").arg(cmd);
             children.push(
                 command
                     .spawn()


### PR DESCRIPTION
Change the way commands are executed so instead of first splitting up the command by whitespace we just pipe the command into `sh -c`.